### PR TITLE
s3-batch-invoke-lambda-mpu-copy

### DIFF
--- a/python/example_code/s3/S3-Batch/Copy-Operation/cfn-s3-batch-ops-mpu-copy.yml
+++ b/python/example_code/s3/S3-Batch/Copy-Operation/cfn-s3-batch-ops-mpu-copy.yml
@@ -1,0 +1,71 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  S3BatchMpuCopyBatchIamRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      Policies:
+        - PolicyName: S3BatchMpuCopyBatchIamRolePolicy0
+          PolicyDocument:
+            Statement:
+              - Action:
+                  - 's3:PutObject*'
+                  - 's3:GetObject*'
+                  - 'lambda:InvokeFunction'
+                  - 's3:GetBucketLocation'
+                Resource: '*'
+                Effect: Allow
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: batchoperations.s3.amazonaws.com
+            Action: 'sts:AssumeRole'
+  S3BatchMpuCopyLambdaiamrole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        - PolicyName: S3BatchMpuCopyLambdaiamRolePolicy0
+          PolicyDocument:
+            Statement:
+              - Action:
+                  - 's3:GetObject*'
+                  - 's3:PutObject*'
+                  - 's3:ListBucket*'
+                Resource: '*'
+                Effect: Allow
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: 'sts:AssumeRole'
+  S3BatchMpuCopyfunction:
+    DependsOn:
+      - S3BatchMpuCopyLambdaiamrole
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Environment:
+        Variables:
+          destination_bucket: DESTINATION_BUCKET
+          max_attempts: 100
+          max_concurrency: 940
+          max_pool_connections: 940
+          multipart_chunksize: 16777216
+      Runtime: python3.7
+      Timeout: 900
+      Description: An S3 Batch Solution for Copying above 5GB S3 Object Size.
+      MemorySize: 600
+      Handler: index.lambda_handler
+      Role: !GetAtt
+        - S3BatchMpuCopyLambdaiamrole
+        - Arn
+      Code:
+        ZipFile:
+            Fn::Sub: |
+                Please copy the Lambda function code from below AWS GitHub page
+
+                'https://github.com/emmaylots/aws-code-samples/blob/master/codes/aws-services/S3/S3-Batch/Copy-Operation/s3-batch-ops-mpu-copy.py'

--- a/python/example_code/s3/S3-Batch/Copy-Operation/notes.txt
+++ b/python/example_code/s3/S3-Batch/Copy-Operation/notes.txt
@@ -1,0 +1,2 @@
+Summary
+

--- a/python/example_code/s3/S3-Batch/Copy-Operation/s3-batch-ops-mpu-copy.py
+++ b/python/example_code/s3/S3-Batch/Copy-Operation/s3-batch-ops-mpu-copy.py
@@ -1,0 +1,119 @@
+import boto3
+import os
+from urllib import parse
+from botocore.client import Config
+from botocore.exceptions import ClientError as S3ClientError
+from boto3.s3.transfer import TransferConfig
+import logging
+
+# Define Environmental Variables
+target_bucket = os.environ['destination_bucket']
+my_max_pool_connections = int(os.environ['max_pool_connections'])
+my_max_concurrency = int(os.environ['max_concurrency'])
+my_multipart_chunksize = int(os.environ['multipart_chunksize'])
+my_max_attempts = int(os.environ['max_attempts'])
+
+# Set and Declare COnfiguration Parameters
+transfer_config = TransferConfig(max_concurrency=my_max_concurrency, multipart_chunksize=my_multipart_chunksize)
+config = Config(max_pool_connections=my_max_pool_connections, retries = {'max_attempts': my_max_attempts})
+
+
+# Instantiate S3Client
+s3Client = boto3.resource('s3',config=config)
+
+# # Set up logging
+# logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(asctime)s: %(message)s')
+logger = logging.getLogger(__name__)
+logger.setLevel('INFO')
+
+# Enable Verbose logging for Troubleshooting
+# boto3.set_stream_logger("")
+
+
+def lambda_handler(event, context):
+    # Parse job parameters from Amazon S3 batch operations
+    jobId = event['job']['id']
+    invocationId = event['invocationId']
+    invocationSchemaVersion = event['invocationSchemaVersion']
+
+    # Prepare results
+    results = []
+
+    # Parse Amazon S3 Key, Key Version, and Bucket ARN
+    taskId = event['tasks'][0]['taskId']
+    # use unquote_plus to handle various characters in S3 Key name
+    s3Key = parse.unquote_plus(event['tasks'][0]['s3Key'], encoding='utf-8')
+    s3VersionId = event['tasks'][0]['s3VersionId']
+    s3BucketArn = event['tasks'][0]['s3BucketArn']
+    s3Bucket = s3BucketArn.split(':')[-1]
+
+    try:
+        # Prepare result code and string
+        resultCode = None
+        resultString = None
+        # Construct Copy Object
+        copy_source = {'Bucket': s3Bucket, 'Key': s3Key}
+        if s3VersionId is not None:
+            copy_source['VersionId'] = s3VersionId
+
+        # Construct New Path
+        # Construct New Key
+        newKey = s3Key
+        newBucket = target_bucket
+
+        # Initiate the Actual Copy Operation and include transfer config option
+        logger.info(f"starting copy between SOURCEBUCKET: {s3Bucket} and DESTINATIONBUCKET: {newBucket}")
+        response = s3Client.meta.client.copy(copy_source, newBucket, newKey, Config=transfer_config)
+        # Confirm copy was successful
+        logger.info("Successfully completed the copy process!")
+
+        # Mark as succeeded
+        resultCode = 'Succeeded'
+        resultString = str(response)
+    except S3ClientError as e:
+        # log errors, some errors does not have a response, so handle them
+        logger.error(f"Unable to complete requested operation, see Clienterror details below:")
+        if e.response is not None:
+            logger.error(e.response)
+            errorCode = e.response.get('Error').get('Code')
+            errorMessage = e.response.get('Error').get('Message')
+            errorS3RequestID = e.response.get('ResponseMetadata').get('RequestId')
+            errorS3ExtendedRequestID = e.response.get('ResponseMetadata').get('HostId')
+            if errorCode == 'RequestTimeout':
+                resultCode = 'TemporaryFailure'
+                resultString = 'Retry request to Amazon S3 due to timeout.'
+            else: # Ensure the Batch Reporting includes Support Information
+                resultCode = 'PermanentFailure'
+                resultString = '{}: {}: {}: {}'.format(errorCode, errorMessage, errorS3RequestID, errorS3ExtendedRequestID)
+        else:
+            logger.error(e)
+            resultCode = 'PermanentFailure'
+            resultString = '{}'.format(e)
+    except Exception as e:
+        # log errors, some errors does not have a response, so handle them
+        logger.error(f"Unable to complete requested operation, see AWS Service error details below:")
+        if e.response is not None:
+            logger.error(e.response)
+            errorCode = e.response.get('Error').get('Code')
+            errorMessage = e.response.get('Error').get('Message')
+            errorS3RequestID = e.response.get('ResponseMetadata').get('RequestId')
+            errorS3ExtendedRequestID = e.response.get('ResponseMetadata').get('HostId')
+            resultString = '{}: {}: {}: {}'.format(errorCode, errorMessage, errorS3RequestID, errorS3ExtendedRequestID)
+
+        else:
+            logger.error(e)
+            resultString = 'Exception: {}'.format(e)
+        resultCode = 'PermanentFailure'
+    finally:
+        results.append({
+            'taskId': taskId,
+            'resultCode': resultCode,
+            'resultString': resultString
+        })
+
+    return {
+        'invocationSchemaVersion': invocationSchemaVersion,
+        'treatMissingKeysAs': 'PermanentFailure',
+        'invocationId': invocationId,
+        'results': results
+    }


### PR DESCRIPTION
Boto3 code and Cloudformation template to copy objects larger than 5GB using S3 Batch Operations Invoke Lambda

*Issue #, if available:* At the moment S3 batch copy operation supports only 5GB object size. 

*Description of changes:* The Boto3 code and Cloudformation template allows copying objects larger than 5GB within same region and cross region. Successfully tested with 2TB object size in same region EU-WEST-2 and 1TB cross region EU-WEST-2 to US-EAST-1


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
